### PR TITLE
add none format

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	predefineFormat = []string{"json", "apache2", "nginx", "rfc3164", "rfc5424"}
+	predefineFormat = []string{"json", "apache2", "nginx", "rfc3164", "rfc5424", "none"}
 	customiseFormat = "customise"
 )
 


### PR DESCRIPTION
Problem:
now user have to select a format when user want to use custom log

Solution:
add none format, this format will collect log and save to the log field

Issue:
https://github.com/rancher/rancher/issues/17192